### PR TITLE
Removed notification creating in Task Creation

### DIFF
--- a/backend/src/main/java/com/backend/practiceproedit/service/TaskService.java
+++ b/backend/src/main/java/com/backend/practiceproedit/service/TaskService.java
@@ -5,8 +5,6 @@ import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.*;
 import com.google.firebase.cloud.FirestoreClient;
 import org.springframework.stereotype.Service;
-import com.backend.practiceproedit.model.Notification;
-import com.backend.practiceproedit.service.NotificationService;
 import com.backend.practiceproedit.service.FirebaseService;
 
 import java.util.ArrayList;
@@ -21,12 +19,10 @@ public class TaskService {
 
     private final Firestore db;
     private final FirebaseService firebaseService;
-    private final NotificationService notificationService;
 
-    public TaskService(FirebaseService firebaseService, NotificationService notificationService) {
+    public TaskService(FirebaseService firebaseService) {
         this.firebaseService = firebaseService;
         this.db = firebaseService.getFirestore();
-        this.notificationService = notificationService;
     }
 
     // Create a new task under a specific project (sub-collection)
@@ -44,21 +40,6 @@ public class TaskService {
 
         // Save to Firestore
         db.collection("projects").document(projectId).collection("tasks").document(taskId).set(task).get();
-
-        // 🔔 Fetch project to get client and admin IDs
-        DocumentSnapshot projectDoc = db.collection("projects").document(projectId).get().get();
-        if (projectDoc.exists()) {
-            String clientId = projectDoc.getString("userId");
-            String adminId = "ADMIN_STATIC_ID"; // Change this if you have a real admin userId stored
-
-            String message = "A new task was added to project: " + projectDoc.getString("title");
-
-            Notification clientNotif = new Notification(clientId, "task", message, projectId, false, Timestamp.now());
-            Notification adminNotif = new Notification(adminId, "task", message, projectId, false, Timestamp.now());
-
-            notificationService.createNotification(clientNotif);
-            notificationService.createNotification(adminNotif);
-        }
 
         return taskId;
     }
@@ -85,21 +66,6 @@ public class TaskService {
 
         db.collection("projects").document(projectId).collection("tasks")
                 .document(taskId).set(updatedTask).get();
-
-        // 🔔 Send notification
-        DocumentSnapshot projectDoc = db.collection("projects").document(projectId).get().get();
-        if (projectDoc.exists()) {
-            String clientId = projectDoc.getString("userId");
-            String adminId = "ADMIN_STATIC_ID"; // Replace with dynamic adminId if available
-
-            String message = "A task was updated in project: " + projectDoc.getString("title");
-
-            Notification clientNotif = new Notification(clientId, "task", message, projectId, false, Timestamp.now());
-            Notification adminNotif = new Notification(adminId, "task", message, projectId, false, Timestamp.now());
-
-            notificationService.createNotification(clientNotif);
-            notificationService.createNotification(adminNotif);
-        }
     }
 
     // Delete a task by its ID


### PR DESCRIPTION
Removed create notification when a task is created or updated by the editor. Because this causes too many firestore document writes.